### PR TITLE
Add comprehensive help command

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -16,6 +16,7 @@ from bot.config import TELEGRAM_TOKEN, PERSISTENCE_FILE
 from bot.constants import ASK_LOCATION, ASK_TIME, ASK_CUSTOM_TIME
 from bot.handlers.start import (
     start,
+    help_cmd,
     tz_cmd,
     link_cmd,
     contactlink_cmd,
@@ -52,13 +53,14 @@ def build_app() -> Application:
     # Deep-link /start with parameter *before* bare /start so it can catch the param variant
     app.add_handler(
         MessageHandler(
-        filters.Regex(r"^/start\s+\S+"),  # only matches when a param exists
-        start_param_entry,
-        block=False,  # don't block other handlers
+            filters.Regex(r"^/start\s+\S+"),  # only matches when a param exists
+            start_param_entry,
+            block=False,  # don't block other handlers
         )
     )
     # app.add_handler(MessageHandler(filters.Regex(r"^/start(\s+.+)?$"), start_param_entry))
     app.add_handler(CommandHandler("start", start))
+    app.add_handler(CommandHandler("help", help_cmd))
 
     # Core commands
     app.add_handler(CommandHandler("tz", tz_cmd))


### PR DESCRIPTION
## Summary
- add a reusable help catalogue that describes every bot command
- expose a /help handler and mention it in the /start welcome message

## Testing
- PYTHONPATH=. pytest *(fails: tests/unit/test_deadline_flow.py::test_deadline_notifies_all_contacts_and_owner_ack – AttributeError: 'FakeJob' object has no attribute 'data')*


------
https://chatgpt.com/codex/tasks/task_e_68caaad6ef2c8330b925069b0c13c669