### PR TITLE
Document environment configuration for cloud deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Copy this file to .env (or export the variables another way) before running the bot.
+# Values marked REQUIRED must be set for the chosen deployment mode.
+
+# === Core ===
+# REQUIRED: Telegram bot token. Prefer BOT_TOKEN; TELEGRAM_TOKEN is accepted for backward compatibility.
+BOT_TOKEN=123456:ABC-DEF_your_token_here
+
+# Optional: default timezone for interpreting HH:MM input from runners.
+# Must be a valid IANA timezone.
+DEFAULT_TZ=Asia/Singapore
+
+# Optional: location of the pickle persistence file.
+# For stateless deployments, point this to durable storage or override with a cloud database.
+STATE_FILE=saferunner_data.pkl
+
+# Optional: set to true to DM contacts when they are added as an alert.
+# Accepts truthy values such as: true, yes, 1. Anything else falls back to false.
+ALERT=false
+
+# === Webhook mode (python -m bot.webhook) ===
+# REQUIRED when using the webhook runner: publicly reachable base URL (https://example.com)
+WEBHOOK_URL=https://your.domain
+
+# Optional: path appended to WEBHOOK_URL for Telegram to call. Must start with '/'.
+WEBHOOK_PATH=/telegram
+
+# Optional: secret token Telegram includes with each webhook call. Leave blank to disable.
+WEBHOOK_SECRET=
+
+# Optional: listening interface & port for the aiohttp server started by run_webhook().
+LISTEN_ADDR=0.0.0.0
+PORT=8080

--- a/README.md
+++ b/README.md
@@ -15,10 +15,23 @@ No group chat required.
   - Contacts ➜ runners (`/contactlink`)
 
 ## Config: tokens & .env
-The bot reads your token from:
-1) `BOT_TOKEN` (preferred), else
-2) `TELEGRAM_TOKEN`, else
-3) defaults to `"PUT-YOUR-TOKEN-HERE"`
+
+1. Copy `.env.example` to `.env` (or export the variables another way).
+2. Set the values that match your deployment mode:
+
+| Variable | Required? | Purpose |
+| --- | --- | --- |
+| `BOT_TOKEN` | ✅ Always | Primary token used by both runners. `TELEGRAM_TOKEN` remains a legacy fallback. |
+| `DEFAULT_TZ` | Optional | IANA timezone used when runners provide HH:MM deadlines. Defaults to `Asia/Singapore`. |
+| `STATE_FILE` | Optional | Path for the pickle persistence file. Point this at durable storage in stateless/cloud deployments. |
+| `ALERT` | Optional | When `true`, DM contacts when they’re added as alerts. Accepts `true/false`, `yes/no`, `1/0`. |
+| `WEBHOOK_URL` | ✅ Webhook runner | Public HTTPS base URL Telegram should call (e.g., `https://example.com`). |
+| `WEBHOOK_PATH` | Optional | Request path appended to `WEBHOOK_URL`. Defaults to `/telegram`. |
+| `WEBHOOK_SECRET` | Optional | Secret token used to validate incoming webhook calls. |
+| `LISTEN_ADDR` | Optional | Bind address for the webhook server. Defaults to `0.0.0.0`. |
+| `PORT` | Optional | Listen port for the webhook server. Defaults to `8080`. |
+
+> ℹ️ If you stick with long polling (`python -m bot.main`), the webhook-specific variables are ignored.
 
 ## Commands
 - `/contactlink` – (for contacts) generate a link you can share with runners
@@ -34,5 +47,5 @@ The bot reads your token from:
 ```bash
 python -m venv .venv && source .venv/bin/activate  # or .venv\Scripts\activate on Windows
 pip install -r requirements.txt
-export TELEGRAM_TOKEN=123456:ABC...   # set your bot token
-python -m bot.main
+cp .env.example .env  # then edit the values for your deployment
+python -m bot.main    # or: python -m bot.webhook

--- a/bot/config.py
+++ b/bot/config.py
@@ -52,5 +52,20 @@ DEFAULT_TZ = os.environ.get("DEFAULT_TZ", "Asia/Singapore")
 # Persistence filename (PicklePersistence)
 PERSISTENCE_FILE = os.environ.get("STATE_FILE", "saferunner_data.pkl")
 
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+
+    return default
+
+
 # Whether admin will be alerted on being added as alert
-ALERT_WHEN_ADDED = os.environ.get("ALERT", False)
+ALERT_WHEN_ADDED = _env_flag("ALERT", False)


### PR DESCRIPTION
## Summary
- document all required and optional environment variables in the README and point to the new .env example
- add a committed `.env.example` containing sane defaults for polling and webhook deployments
- parse the ALERT environment variable as a proper boolean flag in configuration

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceab4953d88330987e999848625e39